### PR TITLE
Update client.py url

### DIFF
--- a/tap_lookml/client.py
+++ b/tap_lookml/client.py
@@ -104,7 +104,7 @@ class GitClient(object):
                  api_token,
                  user_agent=None):
         self.__api_token = api_token
-        self.base_url = "https://api.github.com"
+        self.base_url = "https://github.toasttab.com/api/v3/"
         self.__user_agent = user_agent
         self.__session = requests.Session()
         self.__verified = False
@@ -125,7 +125,7 @@ class GitClient(object):
             raise Exception('Error: Missing api_token in config.json.')
         headers = {}
         # Endpoint: simple API call to return a single record (current User) to test access
-        url = 'https://api.github.com/user'
+        url = 'https://github.toasttab.com/api/v3/user'
         if self.__user_agent:
             headers['User-Agent'] = self.__user_agent
         headers['Accept'] = 'application/vnd.github.v3+json'


### PR DESCRIPTION
update enterprise url -- the url structure is different for enterprise

# Description of change
https://toasttab.atlassian.net/browse/DIP-5620

To fix our lookml pull.

# Manual QA steps
The url structure in the tap:
https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28
`https://api.github.com/repos/OWNER/REPO/contents/PATH`

The URL structure we need for enterprise:
https://docs.github.com/en/enterprise-server@3.13/rest/repos/contents?apiVersion=2022-11-28
`http(s)://HOSTNAME/api/v3/repos/OWNER/REPO/contents/PATH`

 
# Risks
 - 
 
# Rollback steps
 - revert this branch
