### PR TITLE
Update client.py - remove extra backslash

### DIFF
--- a/tap_lookml/client.py
+++ b/tap_lookml/client.py
@@ -104,7 +104,7 @@ class GitClient(object):
                  api_token,
                  user_agent=None):
         self.__api_token = api_token
-        self.base_url = "https://github.toasttab.com/api/v3/"
+        self.base_url = "https://github.toasttab.com/api/v3"
         self.__user_agent = user_agent
         self.__session = requests.Session()
         self.__verified = False


### PR DESCRIPTION
update url for extra slash

# Description of change

An extra backslash is breaking the API call

# Manual QA steps
 
![Screenshot 2024-05-23 at 4 01 16 PM](https://github.com/alisa-aylward-toast/tap-lookml/assets/55718002/6a7a1cf0-e926-420c-9487-4fab178c7160)

making the api call directly:
![Screenshot 2024-05-23 at 4 04 07 PM](https://github.com/alisa-aylward-toast/tap-lookml/assets/55718002/aa80c4e5-fd4a-40bf-805e-bad06aaa7319)

Peep the corrected url:
![Screenshot 2024-05-23 at 4 04 16 PM](https://github.com/alisa-aylward-toast/tap-lookml/assets/55718002/c5b047cf-97b0-4a99-8446-3e1a105e6603)

# Risks
 - 
 
# Rollback steps
 - revert this branch
